### PR TITLE
perf: avoid signing transactions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,12 @@ repos:
     -   id: check-yaml
 
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         name: black
@@ -22,13 +22,13 @@ repos:
         additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic, flake8-type-checking]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests, types-setuptools]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.21
+    rev: 0.7.22
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]

--- a/ape_titanoboa/accounts.py
+++ b/ape_titanoboa/accounts.py
@@ -1,0 +1,22 @@
+from typing import TYPE_CHECKING
+
+from ape_test.accounts import TestAccount
+
+if TYPE_CHECKING:
+    from ape.api.transactions import ReceiptAPI, TransactionAPI
+
+
+class BoaAccount(TestAccount):
+    def call(
+        self,
+        txn: "TransactionAPI",
+        send_everything: bool = False,
+        private: bool = False,
+        sign: bool = False,
+        **signer_options,
+    ) -> "ReceiptAPI":
+        """
+        Override switched the default value of ``sign`` from ``True`` to ``False``,
+        as there is no reason to sign when using Boa.
+        """
+        return super().call(txn, send_everything, private=private, sign=sign, **signer_options)

--- a/ape_titanoboa/provider.py
+++ b/ape_titanoboa/provider.py
@@ -23,6 +23,7 @@ from eth_abi import decode
 from eth_pydantic_types import HexBytes, HexStr
 from eth_utils import ValidationError, to_hex
 
+from ape_titanoboa.accounts import BoaAccount
 from ape_titanoboa.config import BoaForkConfig, ForkBlockIdentifier
 from ape_titanoboa.trace import BoaTrace
 from ape_titanoboa.transactions import BoaReceipt, BoaTransaction
@@ -529,10 +530,10 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
 
         # Generate account for the first time.
         keys = self._generate_keys(index)
-        account = self.account_manager.init_test_account(
-            index,
-            keys[0],
-            str(keys[1]),
+        account = BoaAccount(
+            index=index,
+            address_str=keys[0],
+            private_key=f"{keys[1]}",
         )
         self._accounts[index] = account
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     url="https://github.com/ApeWorX/ape-titanoboa",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.8.22,<0.9",
+        "eth-ape>=0.8.25,<0.9",
         "cchecksum>=0.0.3,<1",
         "titanoboa>=0.2.5,<0.3",
         "web3>=7.6.1,<8",

--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,15 @@ extras_require = {
         "ape-vyper>=0.8.8,<0.9",  # For compiling test contracts
     ],
     "lint": [
-        "black>=24.10.0",  # auto-formatter and linter
-        "mypy>=1.14.1",  # Static type analyzer
+        "black>=25.1.0",  # auto-formatter and linter
+        "mypy>=1.15.0",  # Static type analyzer
         "flake8>=7.1.1,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=4.0.1,<5",  # Detect print statements left in code
         "flake8-pydantic",  # For detecting issues with Pydantic models
         "flake8-type-checking",  # Detect imports to move in/out of type-checking blocks
-        "isort>=5.13.2",  # Import sorting linter
-        "mdformat>=0.7.21",  # Auto-formatter for markdown
+        "isort>=6.0.0",  # Import sorting linter
+        "mdformat>=0.7.22",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.2",  # Allows configuring in pyproject.toml

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -97,9 +97,9 @@ def test_send_call(contract_instance, owner, contract, networks, run_fork_tests)
             polyhedra = Contract("0x465C15e9e2F3837472B0B204e955c5205270CA9E")
             assert polyhedra.name() == "tZKJ"
 
-    # Show it works the same back on local.
-    result = contract_instance.myNumber()
-    assert result == 123
+        # Show it works the same back on local.
+        result = contract_instance.myNumber()
+        assert result == 123
 
 
 def test_get_receipt(contract_instance, owner, chain, networks, run_fork_tests):
@@ -664,6 +664,9 @@ def test_fork(networks, owner, run_fork_tests):
         pytest.skip("Fork tests skipped")
 
     # Start off connected to a live network.
+    if not run_fork_tests:
+        pytest.skip("Fork tests skipped")
+
     with networks.ethereum.sepolia.use_provider("alchemy"):
         # When connected to a live network, it is typical to fork it for
         # running simulations.

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -41,6 +41,7 @@ def test_deploy_contract(contract, owner, networks):
 def test_send_transaction(chain, contract_instance, contract, owner, networks, not_owner):
     expected_block = chain.provider.get_block("pending")
     tx = contract_instance.setNumber(321, sender=owner)
+    assert tx.signature is None
     assert not tx.failed
     assert tx.block_number == expected_block.number
 
@@ -74,6 +75,12 @@ def test_send_transaction_payable(contract_instance, owner):
     contract_instance.gimmeMoney(value=1, sender=owner)
     with reverts():
         contract_instance.gimmeMoney(sender=owner)
+
+
+def test_send_transaction_sign(contract_instance, owner):
+    tx = contract_instance.gimmeMoney(value=1, sender=owner, sign=True)
+    assert tx.signature is not None
+    assert not tx.failed
 
 
 def test_send_call(contract_instance, owner, contract, networks, run_fork_tests):


### PR DESCRIPTION
### What I did

This makes testing faster as it skips signing.
Requires core PR: https://github.com/ApeWorX/ape/pull/2483

Honestly, didn't see as much of a perf gain as I hoped, but you do see some.
Command:

x3
```sh
ape test tests/test_provider.py::test_send_transaction
```

before:

```
1 passed in 0.46s
1 passed in 0.43s
1 passed in 0.43s
```

after:

```
1 passed in 0.43s
1 passed in 0.41s
1 passed in 0.40s
```

Tests will fail on the PR and lint, until the linked core PR is merged and available.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
