### PR TITLE
feat: allow configuring `auto_mine` default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,11 +1,12 @@
 ---
 name: Bug report
 about: Report an error that you've encountered.
-labels: 'bug'
+labels: bug
 ---
+
 ### Environment information
 
-* `ape` and plugin versions:
+- `ape` and plugin versions:
 
 ```
 $ ape --version
@@ -15,16 +16,16 @@ $ ape plugins list
 # ...copy and paste result of above command here...
 ```
 
-* Python Version: x.x.x
-* OS: osx/linux/win
+- Python Version: x.x.x
+- OS: osx/linux/win
 
 ### What went wrong?
 
 Please include information like:
 
-* what command you ran
-* the code that caused the failure (see [this link](https://help.github.com/articles/basic-writing-and-formatting-syntax/) for help with formatting code)
-* full output of the error you received
+- what command you ran
+- the code that caused the failure (see [this link](https://help.github.com/articles/basic-writing-and-formatting-syntax/) for help with formatting code)
+- full output of the error you received
 
 ### How can it be fixed?
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,15 +1,15 @@
 ---
 name: Feature request
 about: Request a new feature, or an improvement to existing functionality.
-labels: 'enhancement'
+labels: enhancement
 ---
 
 ### Overview
 
 Provide a simple overview of what you wish to see added. Please include:
 
-* What you are trying to do
-* Why Ape's current functionality is inadequate to address your goal
+- What you are trying to do
+- Why Ape's current functionality is inadequate to address your goal
 
 ### Specification
 

--- a/.github/ISSUE_TEMPLATE/work-item.md
+++ b/.github/ISSUE_TEMPLATE/work-item.md
@@ -1,14 +1,15 @@
 ---
 name: Work item
 about: New work item for Ape team
-labels: 'backlog'
-
+labels: backlog
 ---
 
 ### Elevator pitch:
+
 <!-- 1-2 line summary of the scope of this work item -->
 
 ### Value:
+
 <!--
   Who is this for?
   Persona or group of people whom will derive value from the scenario.
@@ -16,26 +17,32 @@ labels: 'backlog'
 -->
 
 ### Dependencies:
+
 <!-- Call out key people, teams, tech dependencies, or assumptions. -->
 
 ### Design approach:
+
 <!--
   Free text / diagram / whiteboard picture / etc. that clearly shows your approach and considerations to build the task list.
   Existing code patterns in production code base that you will base your work off of.
 -->
 
 ### Task list:
+
 <!-- Bulleted list describing the exit criteria, desired end state and any documentation, monitors, work for DRI, etc. that will need to be added to make sure someone else can support once it's live. -->
-* [ ] Tasks go here
+
+- [ ] Tasks go here
 
 ### Estimated completion date:
 
-
 ### Design review:
+
 <!-- 1-2 people needed for signoff -->
+
 Do not signoff unless:
-- 1) agreed the tasks and design approach will achieve acceptance, and
-- 2) the work can be completed by one person within the SLA.
-Design reviewers should consider simpler approaches to achieve goals.
+
+- 1. agreed the tasks and design approach will achieve acceptance, and
+- 2. the work can be completed by one person within the SLA.
+     Design reviewers should consider simpler approaches to achieve goals.
 
 (Please leave a comment to sign off)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 ### What I did
 
 <!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
+
 fixes: #
 
 ### How I did it

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,12 @@ jobs:
             python-version: ${{ matrix.python-version }}
 
         - name: Run Tests
-          run: ape test
+          run: |
+            if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+              ape test
+            else
+              ape test --no-forks
+            fi
           env:
             WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
             ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use Titanoboa as a provider in Ape.
 
 ## Dependencies
 
-* [python3](https://www.python.org/downloads) version 3.9 or greater, python3-dev
+- [python3](https://www.python.org/downloads) version 3.9 or greater, python3-dev
 
 ## Installation
 

--- a/ape_titanoboa/config.py
+++ b/ape_titanoboa/config.py
@@ -48,3 +48,8 @@ class BoaConfig(PluginConfig):
     """
     To enable fast mode, set to ``True``.
     """
+
+    auto_mine: bool = True
+    """
+    Set to ``False`` to disable auto-mining.
+    """

--- a/ape_titanoboa/provider.py
+++ b/ape_titanoboa/provider.py
@@ -48,7 +48,6 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
     NAME: ClassVar[str] = "boa"
 
     # Flags.
-    _auto_mine: bool = True
     _connected: bool = False
 
     # Account state.
@@ -106,11 +105,11 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
 
     @property
     def auto_mine(self) -> bool:
-        return self._auto_mine
+        return self.config.auto_mine
 
     @auto_mine.setter
     def auto_mine(self, value):
-        self._auto_mine = value
+        self.config.auto_mine = value
 
     @cached_property
     def mnemonic_seed(self) -> bytes:
@@ -389,7 +388,7 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
         receipt = BoaReceipt(**data)
 
         # Prepare new block/transaction.
-        if self._auto_mine:
+        if self.auto_mine:
             # Advance the chain.
             self._blocks.append({"ts": execution_timestamp, "txns": [txn_hash]})
             self._canonical_transactions[txn_hash] = data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ block_identifier = 21551111
 [tool.ape.ethereum.local]
 default_provider = "boa"
 
+[tool.ape.ethereum.mainnet_fork]
+default_provider = "boa"
+
+[tool.ape.ethereum.sepolia_fork]
+default_provider = "boa"
+
 [tool.ape.test]
 show_internal = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ default_provider = "boa"
 [tool.ape.ethereum.sepolia_fork]
 default_provider = "boa"
 
+[tool.ape.ethereum.holesky_fork]
+default_provider = "boa"
+
 [tool.ape.test]
 show_internal = true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,19 @@ if TYPE_CHECKING:
     from ape.contracts import ContractContainer, ContractInstance
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--no-forks",
+        action="store_true",
+        help="Don't run tests requiring forked networks",
+    )
+
+
+@pytest.fixture(scope="session")
+def run_fork_tests(request):
+    return not request.config.getoption("--no-forks")
+
+
 @pytest.fixture(scope="session")
 def contract(project) -> "ContractContainer":
     return project.VyperContract

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -284,7 +284,7 @@ def test_ChainManager_mine(chain):
     assert chain.blocks.height == height + 1
 
 
-def test_auto_mine(chain, owner):
+def test_auto_mine(chain, owner, project):
     assert chain.provider.auto_mine
     chain.provider.auto_mine = False
     assert not chain.provider.auto_mine
@@ -305,6 +305,12 @@ def test_auto_mine(chain, owner):
     assert chain.blocks.height == height
 
     chain.provider.auto_mine = True
+
+    # Show can set auto-mine in config.
+    with project.temp_config(titanoboa={"auto_mine": True}):
+        assert chain.provider.auto_mine
+    with project.temp_config(titanoboa={"auto_mine": False}):
+        assert not chain.provider.auto_mine
 
 
 def test_snapshot(chain):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -11,10 +11,12 @@ from ape_titanoboa.config import DEFAULT_TEST_CHAIN_ID
 from ape_titanoboa.trace import BoaTrace
 
 
-def test_is_connected(chain, networks):
+def test_is_connected(chain, networks, run_fork_tests):
     assert chain.provider.is_connected
-    with networks.ethereum.sepolia_fork.use_provider("boa"):
-        assert chain.provider.is_connected
+
+    if run_fork_tests:
+        with networks.ethereum.sepolia_fork.use_provider("boa"):
+            assert chain.provider.is_connected
 
 
 def test_deploy_contract(contract, owner, networks):
@@ -74,25 +76,26 @@ def test_send_transaction_payable(contract_instance, owner):
         contract_instance.gimmeMoney(sender=owner)
 
 
-def test_send_call(contract_instance, owner, contract, networks):
+def test_send_call(contract_instance, owner, contract, networks, run_fork_tests):
     result = contract_instance.myNumber()
     assert result == 123
 
-    with networks.ethereum.sepolia_fork.use_provider("boa"):
-        # fork_contract_instance = contract.deploy(111, sender=owner)
-        # result = fork_contract_instance.myNumber()
-        # assert result == 111
+    if run_fork_tests:
+        with networks.ethereum.sepolia_fork.use_provider("boa"):
+            # fork_contract_instance = contract.deploy(111, sender=owner)
+            # result = fork_contract_instance.myNumber()
+            # assert result == 111
 
-        # Interact with apip Sepolia contract.
-        polyhedra = Contract("0x465C15e9e2F3837472B0B204e955c5205270CA9E")
-        assert polyhedra.name() == "tZKJ"
+            # Interact with apip Sepolia contract.
+            polyhedra = Contract("0x465C15e9e2F3837472B0B204e955c5205270CA9E")
+            assert polyhedra.name() == "tZKJ"
 
     # Show it works the same back on local.
     result = contract_instance.myNumber()
     assert result == 123
 
 
-def test_get_receipt(contract_instance, owner, chain, networks):
+def test_get_receipt(contract_instance, owner, chain, networks, run_fork_tests):
     local_tx = contract_instance.setNumber(321, sender=owner)
     actual = chain.provider.get_receipt(local_tx.txn_hash)
     assert actual.txn_hash == local_tx.txn_hash
@@ -101,46 +104,47 @@ def test_get_receipt(contract_instance, owner, chain, networks):
     with pytest.raises(TransactionNotFoundError):
         chain.provider.get_receipt("asdfasdfasdf")
 
-    # Get a sepolia receipt.
-    with networks.ethereum.sepolia_fork.use_provider("boa"):
-        txn_hash = "0x68605140856c13038d325048c411aed98cc1eecc189f628a38edb597f6b9679e"
-        receipt = chain.provider.get_receipt(txn_hash)
-        assert receipt.txn_hash == txn_hash
+    if run_fork_tests:
+        # Get a sepolia receipt.
+        with networks.ethereum.sepolia_fork.use_provider("boa"):
+            txn_hash = "0x68605140856c13038d325048c411aed98cc1eecc189f628a38edb597f6b9679e"
+            receipt = chain.provider.get_receipt(txn_hash)
+            assert receipt.txn_hash == txn_hash
 
-        # Ensure the local transaction we made isn't available.
-        with pytest.raises(TransactionNotFoundError):
-            _ = chain.provider.get_receipt(local_tx.txn_hash)
+            # Ensure the local transaction we made isn't available.
+            with pytest.raises(TransactionNotFoundError):
+                _ = chain.provider.get_receipt(local_tx.txn_hash)
 
-        sepolia_tx = owner.transfer(owner, 0)
-        assert chain.provider.get_receipt(sepolia_tx.txn_hash).txn_hash == sepolia_tx.txn_hash
-
-    # Ensure the sepolia-fork transaction we made isn't available.
-    with pytest.raises(TransactionNotFoundError):
-        _ = chain.provider.get_receipt(sepolia_tx.txn_hash)
-
-    # Get a holesky receipt.
-    with networks.ethereum.holesky_fork.use_provider("boa"):
-        txn_hash = "0x611745e08130a55df98a3758ac6029fb68a60651dad15d6ee6435e457ac8ed34"
-        receipt = chain.provider.get_receipt(txn_hash)
-        assert receipt.txn_hash == txn_hash
-
-        # Ensure the local transaction we made isn't available.
-        with pytest.raises(TransactionNotFoundError):
-            _ = chain.provider.get_receipt(local_tx.txn_hash)
+            sepolia_tx = owner.transfer(owner, 0)
+            assert chain.provider.get_receipt(sepolia_tx.txn_hash).txn_hash == sepolia_tx.txn_hash
 
         # Ensure the sepolia-fork transaction we made isn't available.
         with pytest.raises(TransactionNotFoundError):
             _ = chain.provider.get_receipt(sepolia_tx.txn_hash)
 
-        holesky_tx = owner.transfer(owner, 0)
-        assert chain.provider.get_receipt(holesky_tx.txn_hash).txn_hash == holesky_tx.txn_hash
+        # Get a holesky receipt.
+        with networks.ethereum.holesky_fork.use_provider("boa"):
+            txn_hash = "0x611745e08130a55df98a3758ac6029fb68a60651dad15d6ee6435e457ac8ed34"
+            receipt = chain.provider.get_receipt(txn_hash)
+            assert receipt.txn_hash == txn_hash
 
-    # Ensure the holesky-fork transaction we made isn't available.
-    with pytest.raises(TransactionNotFoundError):
-        _ = chain.provider.get_receipt(holesky_tx.txn_hash)
+            # Ensure the local transaction we made isn't available.
+            with pytest.raises(TransactionNotFoundError):
+                _ = chain.provider.get_receipt(local_tx.txn_hash)
+
+            # Ensure the sepolia-fork transaction we made isn't available.
+            with pytest.raises(TransactionNotFoundError):
+                _ = chain.provider.get_receipt(sepolia_tx.txn_hash)
+
+            holesky_tx = owner.transfer(owner, 0)
+            assert chain.provider.get_receipt(holesky_tx.txn_hash).txn_hash == holesky_tx.txn_hash
+
+        # Ensure the holesky-fork transaction we made isn't available.
+        with pytest.raises(TransactionNotFoundError):
+            _ = chain.provider.get_receipt(holesky_tx.txn_hash)
 
 
-def test_AccountAPI_nonce(owner, contract, chain, networks):
+def test_AccountAPI_nonce(owner, contract, chain, networks, run_fork_tests):
     """
     Showing the integration with `AccountAPI.nonce` works
     (testing `TitanoboaProvider.get_nonce()` indirectly).
@@ -158,18 +162,19 @@ def test_AccountAPI_nonce(owner, contract, chain, networks):
     vitalik = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
     assert chain.provider.get_nonce(vitalik) == 0
 
-    with networks.ethereum.holesky_fork.use_provider("boa"):
-        # Transact so the nonce changes on the fork.
-        start_nonce = owner.nonce
-        owner.transfer(owner, 9)
-        assert owner.nonce == start_nonce + 1
+    if run_fork_tests:
+        with networks.ethereum.holesky_fork.use_provider("boa"):
+            # Transact so the nonce changes on the fork.
+            start_nonce = owner.nonce
+            owner.transfer(owner, 9)
+            assert owner.nonce == start_nonce + 1
 
-    with networks.ethereum.mainnet_fork.use_provider("boa"):
-        # Mainnet fork boa knows Vitalik's nonce.
-        assert chain.provider.get_nonce(vitalik) > 0
+        with networks.ethereum.mainnet_fork.use_provider("boa"):
+            # Mainnet fork boa knows Vitalik's nonce.
+            assert chain.provider.get_nonce(vitalik) > 0
 
-    # Show the nonce is as it was.
-    assert owner.nonce == nonce_before_fork
+        # Show the nonce is as it was.
+        assert owner.nonce == nonce_before_fork
 
 
 def test_ReceiptAPI_logs(owner, contract_instance):
@@ -194,7 +199,7 @@ def test_ReceiptAPI_events(owner, contract_instance):
     assert actual[0].newNum == 321
 
 
-def test_get_block(chain, networks):
+def test_get_block(chain, networks, run_fork_tests):
     # Earliest block (genesis).
     zero_block = chain.provider.get_block(0)
     earliest_block = chain.provider.get_block("earliest")
@@ -234,20 +239,21 @@ def test_get_block(chain, networks):
         chain.provider.get_block(b"111111")
 
     # Get blocks from sepolia.
-    with networks.ethereum.sepolia_fork.use_provider("boa"):
-        block = chain.provider.get_block("latest")
-        assert block.number >= 7341111  # From configuration.
+    if run_fork_tests:
+        with networks.ethereum.sepolia_fork.use_provider("boa"):
+            block = chain.provider.get_block("latest")
+            assert block.number >= 7341111  # From configuration.
 
-        # Mine.
-        chain.provider.mine(5)
-        block = chain.provider.get_block("latest")
-        assert block.number >= 7341116
-        block = chain.provider.get_block(7341116)
-        assert block.number == 7341116
+            # Mine.
+            chain.provider.mine(5)
+            block = chain.provider.get_block("latest")
+            assert block.number >= 7341116
+            block = chain.provider.get_block(7341116)
+            assert block.number == 7341116
 
-        # Historical block.
-        block = chain.provider.get_block(3)
-        assert block.timestamp == 1634951317
+            # Historical block.
+            block = chain.provider.get_block(3)
+            assert block.timestamp == 1634951317
 
 
 def test_get_transactions_by_block(contract_instance, owner, chain):
@@ -261,15 +267,17 @@ def test_get_transactions_by_block(contract_instance, owner, chain):
     assert to_hex(actual[-1].txn_hash) == tx.txn_hash
 
 
-def test_AccountAPI_balance(owner, networks):
+def test_AccountAPI_balance(owner, networks, run_fork_tests):
     """
     Show the integration with `AccountAPI.balance` works
     (calls `TitanoboaProvider.get_balance()` under-the-hood.
     """
     balance = owner.balance
     assert balance > 0
-    with networks.ethereum.mainnet_fork.use_provider("boa"):
-        assert owner.balance != balance
+
+    if run_fork_tests:
+        with networks.ethereum.mainnet_fork.use_provider("boa"):
+            assert owner.balance != balance
 
     # Show it goes back after fork.
     assert owner.balance == balance
@@ -533,7 +541,7 @@ def test_set_timestamp(chain):
         while now <= start_time:
             now = int(time.time())
 
-    # Show that time is froze after setting the timestamp.
+    # Show that time is frozen after setting the timestamp.
     wait_for_time_to_increase(time_at_start)
     assert chain.pending_timestamp == new_timestamp
 
@@ -610,23 +618,27 @@ def test_onchain_timestamp(chain, contract_instance, owner):
         pytest.fail("Somehow went back in time after mining a new block.")
 
 
-def test_chain_id(chain, networks):
+def test_chain_id(chain, networks, run_fork_tests):
     actual = chain.provider.chain_id
     expected = DEFAULT_TEST_CHAIN_ID
     assert actual == expected
 
-    with networks.ethereum.holesky_fork.use_provider("boa") as holesky_fork:
-        actual = holesky_fork.chain_id
-        expected = 17000  # Holesky
+    if run_fork_tests:
+        with networks.ethereum.holesky_fork.use_provider("boa") as holesky_fork:
+            actual = holesky_fork.chain_id
+            expected = 17000  # Holesky
+            assert actual == expected
+
+        # Show it goes back.
+        actual = chain.provider.chain_id
+        expected = DEFAULT_TEST_CHAIN_ID
         assert actual == expected
 
-    # Show it goes back.
-    actual = chain.provider.chain_id
-    expected = DEFAULT_TEST_CHAIN_ID
-    assert actual == expected
 
+def test_block_identifier(chain, project, networks, run_fork_tests):
+    if not run_fork_tests:
+        pytest.skip("Fork tests skipped")
 
-def test_block_identifier(chain, project, networks):
     with networks.ethereum.sepolia_fork.use_provider("boa"):
         actual = chain.provider.block_identifier
         expected = 7341111  # From configuration.
@@ -637,10 +649,13 @@ def test_block_identifier(chain, project, networks):
             assert chain.provider.block_identifier == "safe"
 
 
-def test_fork(networks, owner):
+def test_fork(networks, owner, run_fork_tests):
     """
     Show we can integrate nicely with Ape's `networks.fork()` method.
     """
+    if not run_fork_tests:
+        pytest.skip("Fork tests skipped")
+
     # Start off connected to a live network.
     with networks.ethereum.sepolia.use_provider("alchemy"):
         # When connected to a live network, it is typical to fork it for


### PR DESCRIPTION
### What I did

allows the user to configure whethere ape-titanoboa auto mines or not.

also, out of annoyance, it disables forks tests when the pr is coming from a fork

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
