### PR TITLE
fix: honor search topics when filtering logs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic, flake8-type-checking]

--- a/ape_titanoboa/provider.py
+++ b/ape_titanoboa/provider.py
@@ -462,12 +462,24 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
                                 # Isn't the correct event (same name, different inputs).
                                 continue
 
-                        # Found the correct event.
-                        # Verify topic-search.
-                        # if log_filter.topic_filter:
-                        #     breakpoint()
+                        # Verify topic search.
+                        found_match = True
+                        actual_topics = tx_event.topics[1:]
+                        for idx, search_topic in enumerate(log_filter.topic_filter[1:]):
+                            if search_topic is None:
+                                # Wildcard.
+                                continue
 
-                        yield tx_event
+                            if not isinstance(search_topic, (list, tuple)):
+                                search_topic = [search_topic]
+
+                            matching_topic = actual_topics[idx]
+                            if matching_topic not in search_topic:
+                                found_match = False
+                                break
+
+                        if found_match:
+                            yield tx_event
 
     def snapshot(self) -> "SnapshotID":
         snapshot = self.env.evm.snapshot()

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-ape>=0.8.27,<0.9",
+        "ethpm-types>=0.6.24,<0.7",
         "cchecksum>=0.0.3,<1",
         "titanoboa>=0.2.5,<0.3",
         "web3>=7.6.1,<8",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     url="https://github.com/ApeWorX/ape-titanoboa",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.8.25,<0.9",
+        "eth-ape>=0.8.27,<0.9",
         "cchecksum>=0.0.3,<1",
         "titanoboa>=0.2.5,<0.3",
         "web3>=7.6.1,<8",

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -763,6 +763,23 @@ def test_get_contract_logs_stop_exceeds_chain_height(chain, contract_instance, o
     assert len(actual) == 3  # Gets all 3, once we exceed the height, we stop.
 
 
+def test_get_contract_logs_no_address(chain, contract_instance, owner):
+    start_block = chain.blocks.height
+    stop_block = chain.blocks.height + 10
+    log_filter = LogFilter(
+        start_block=start_block,
+        stop_block=stop_block,
+        addresses=[],
+        events=[contract_instance.NumberChange.abi],
+    )
+    expected = (
+        r"Address must be either a single hexadecimal encoded address "
+        r"or a non-empty list of hexadecimal encoded addresses"
+    )
+    with pytest.raises(ValueError, match=expected):
+        _ = [log for log in chain.provider.get_contract_logs(log_filter)]
+
+
 def test_prepare_transaction(chain, owner):
     tx = chain.provider.network.ecosystem.create_transaction(nonce=0, sender=owner)
     tx.max_fee = None

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -780,6 +780,21 @@ def test_get_contract_logs_no_address(chain, contract_instance, owner):
         _ = [log for log in chain.provider.get_contract_logs(log_filter)]
 
 
+def test_get_contract_logs_topic_filters(chain, contract_instance, owner):
+    contract_instance.setNumber(10, sender=owner)
+    contract_instance.setNumber(20, sender=owner)
+    contract_instance.setNumber(30, sender=owner)
+    log_filter = LogFilter.from_event(
+        contract_instance.NumberChange,
+        addresses=[contract_instance.address],
+        search_topics={"newNum": 20},
+    )
+    actual = [log for log in chain.provider.get_contract_logs(log_filter)]
+    assert len(actual) == 1  # Gets only 1 because of the topic filter.
+    assert actual[0].event_name == "NumberChange"
+    assert actual[0].event_arguments["newNum"] == 20
+
+
 def test_prepare_transaction(chain, owner):
     tx = chain.provider.network.ecosystem.create_transaction(nonce=0, sender=owner)
     tx.max_fee = None


### PR DESCRIPTION
### What I did

fixes some things in `.get_contact_logs()`, mostly actually honoring the search filters but some other things too, to more align with swapping out with eth-tester in core.

### How I did it

### How to verify it

will require https://github.com/ApeWorX/ethpm-types/pull/151
and https://github.com/ApeWorX/ape/pull/2505

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
