### PR TITLE
fix: issue deploying contract with default payable method

### DIFF
--- a/ape_titanoboa/provider.py
+++ b/ape_titanoboa/provider.py
@@ -17,7 +17,7 @@ from ape.exceptions import (
 )
 from ape_ethereum.transactions import TransactionStatusEnum
 from eth.constants import ZERO_ADDRESS
-from eth.exceptions import Revert
+from eth.exceptions import Revert, WriteProtection
 from eth.vm.spoof import SpoofTransaction
 from eth_abi import decode
 from eth_pydantic_types import HexBytes, HexStr
@@ -278,8 +278,15 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
         computation = self._execute_code(txn.data, txn.gas_limit, receiver=txn.receiver)
         try:
             computation.raise_if_error()
+
         except Revert as err:
             raise self.get_virtual_machine_error(err) from err
+
+        except WriteProtection as err:
+            # This occurs when calling an ABI that does not exist
+            # on a contract with a default payable method. Regular
+            # nodes still seem to revert here, we pretend to do the same.
+            raise ContractLogicError() from err
 
         return HexBytes(computation.output)
 

--- a/ape_titanoboa/provider.py
+++ b/ape_titanoboa/provider.py
@@ -531,14 +531,17 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
 
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         if isinstance(exception, Revert):
-            raw_data = exception.args[0]
-            revert_data = raw_data[4:]
+            if raw_data := exception.args[0]:
+                revert_data = raw_data[4:]
 
-            try:
-                message = decode(("string",), revert_data, strict=False)[0]
-            except Exception:
-                # Likely a custom error.
-                message = to_hex(revert_data)
+                try:
+                    message = decode(("string",), revert_data, strict=False)[0]
+                except Exception:
+                    # Likely a custom error.
+                    message = to_hex(revert_data)
+
+            else:
+                message = VirtualMachineError.DEFAULT_MESSAGE
 
             contract_logic_error = ContractLogicError(
                 base_err=exception,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,6 @@ def not_owner(accounts) -> "AccountAPI":
     return accounts[1]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def contract_instance(contract, owner) -> "ContractInstance":
     return contract.deploy(123, sender=owner)

--- a/tests/contracts/ContractWithDefaultPayable.vy
+++ b/tests/contracts/ContractWithDefaultPayable.vy
@@ -1,0 +1,11 @@
+# pragma version ^0.4.0
+
+# Event for tracking donations
+event Donation:
+    sender: address
+    amount: uint256
+
+@external
+@payable
+def __default__():
+    log Donation(msg.sender, msg.value)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -103,6 +103,14 @@ def test_send_call(contract_instance, owner, contract, networks, run_fork_tests)
         assert result == 123
 
 
+def test_send_call_method_not_exists(chain, contract_instance):
+    tx = chain.provider.network.ecosystem.create_transaction(
+        data="0x12345678000", receiver=contract_instance.address
+    )
+    with pytest.raises(ContractLogicError):
+        _ = chain.provider.send_call(tx)
+
+
 def test_get_receipt(contract_instance, owner, chain, networks, run_fork_tests):
     local_tx = contract_instance.setNumber(321, sender=owner)
     actual = chain.provider.get_receipt(local_tx.txn_hash)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -39,6 +39,16 @@ def test_deploy_contract(contract, owner, networks):
     assert instance.myNumber() == 123
 
 
+def test_deploy_contract_with_default_payable_method(chain, project, owner):
+    """
+    Tests against a bug where if you tried to deploy a contract with a default
+    payable method, Ape's proxy detection system would trigger an error
+    about mutating static-call state.
+    """
+    contract = project.ContractWithDefaultPayable.deploy(sender=owner)
+    assert contract.contract_type.name == "ContractWithDefaultPayable"
+
+
 def test_send_transaction(chain, contract_instance, contract, owner, networks, not_owner):
     expected_block = chain.provider.get_block("pending")
     tx = contract_instance.setNumber(321, sender=owner)


### PR DESCRIPTION
### What I did

For some reason, could not deploy a contract with a default payable method. It had to do with Ape's proxy detection system, which attempt certain contract-calls. In this case, instead of a ContractLogicError like we'd expect, we were getting write-errors from the EVM.

### How I did it

Handle the error and raise a ContractLogicError to tell the proxy system what's up

### How to verify it

You can deploy contracts like:

```
# pragma version ^0.4.0

# Event for tracking donations
event Donation:
    sender: address
    amount: uint256

@external
@payable
def __default__():
    log Donation(msg.sender, msg.value)

```

now

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
