### PR TITLE
fix: issue where sending a transaction without a nonce using impersonated account causes error

### DIFF
--- a/ape_titanoboa/provider.py
+++ b/ape_titanoboa/provider.py
@@ -317,10 +317,7 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
         txn.gas_limit = self.env.evm.get_gas_limit()
         txn.chain_id = self.chain_id
         txn.sender = txn.sender or to_hex(ZERO_ADDRESS)
-
-        if txn.nonce is None:
-            txn.nonce = self._nonces[txn.sender] if txn.sender else 0
-
+        txn.nonce = self._nonces[txn.sender] if txn.nonce is None else txn.nonce
         return txn
 
     def send_transaction(self, txn: "TransactionAPI") -> "ReceiptAPI":

--- a/ape_titanoboa/provider.py
+++ b/ape_titanoboa/provider.py
@@ -318,8 +318,8 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
         txn.chain_id = self.chain_id
         txn.sender = txn.sender or to_hex(ZERO_ADDRESS)
 
-        if txn.nonce is None and txn.sender:
-            txn.nonce = self._nonces[txn.sender]
+        if txn.nonce is None:
+            txn.nonce = self._nonces[txn.sender] if txn.sender else 0
 
         return txn
 
@@ -364,11 +364,12 @@ class BaseTitanoboaProvider(TestProviderAPI, ABC):
         # Figure out the transaction's hash.
         if txn.signature:
             txn_hash = to_hex(txn.txn_hash)
+
         else:
             # Impersonated transaction. Make one up using the sender.
             # NOTE: We use HexStr.__eth_pydantic_validate__ to handle even-digit padding so
             #   hashes are always found (in the case they get corrected later).
-            txn_hash = HexStr.__eth_pydantic_validate__(int(txn.sender, 16) + txn.nonce)
+            txn_hash = HexStr.__eth_pydantic_validate__(int(txn.sender, 16) + (txn.nonce or 0))
 
         logs: list[dict] = [
             convert_boa_log(

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -735,13 +735,15 @@ def test_get_contract_logs(chain, contract_instance, owner):
 
 def test_prepare_transaction(chain, owner):
     tx = chain.provider.network.ecosystem.create_transaction(nonce=0, sender=owner)
+    tx.max_fee = None
     actual = chain.provider.prepare_transaction(tx)
     assert actual.sender == owner
-    assert actual.nonce == owner.nonce
+    assert actual.max_fee is not None
 
 
 def test_prepare_transaction_sender_not_known(chain, owner):
     tx = chain.provider.network.ecosystem.create_transaction(nonce=0, sender=owner)
+    tx.max_fee = None
     actual = chain.provider.prepare_transaction(tx)
     assert actual.sender == owner
-    assert actual.nonce == owner.nonce
+    assert actual.max_fee is not None


### PR DESCRIPTION
### What I did

would get an error trying to do math on None type, this fixes it, related to https://github.com/ApeWorX/ape/pull/2508 but uncovered in a different spot

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
